### PR TITLE
Remove "Already have an account? Sign in now" verbiage on checkout.

### DIFF
--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -379,3 +379,13 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
     background-color: stencilColor("optimizedCheckout-loadingToaster-backgroundColor");
     color: stencilColor("optimizedCheckout-loadingToaster-textColor");
 }
+
+//
+// Tastefully Simple
+// Custom Checkout Overrides
+// -----------------------------------------------------------------------------
+
+// Removes "Already have an account? Sign in now"
+#checkout-customer-guest > fieldset > div > p:nth-child(3) {
+    display: none;
+}


### PR DESCRIPTION
This PR removes the "Already have an account? Sign in now" verbiage on checkout.
The BigCommerce checkout page is a special SPA and access to its files are limited.