### PR TITLE
Dev cart page 2

### DIFF
--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -673,7 +673,6 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
 
 .cart-affiliateInfo {
     text-align: center;
-    display: none;
 }
 
 #cart-affiliate-name, #cart-no-affiliate-name {

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -145,6 +145,7 @@ body {
     color: stencilColor("optimizedCheckout-buttonSecondary-color");
     font-family: stencilFontFamily("optimizedCheckout-buttonSecondary-font"), Arial, Helvetica, sans-serif;
     font-weight: stencilFontWeight("optimizedCheckout-buttonSecondary-font");
+    display: none;
 
     &:focus,
     &:hover {

--- a/config.json
+++ b/config.json
@@ -287,7 +287,7 @@
     "optimizedCheckout-formField-errorColor": "#d14343",
     "optimizedCheckout-formField-inputControlColor": "#476bef",
     "optimizedCheckout-step-borderColor": "#dddddd",
-    "optimizedCheckout-header-borderColor": "#dddddd",
+    "optimizedCheckout-header-borderColor": "#f5f5f5",
     "optimizedCheckout-header-textColor": "#333333",
     "optimizedCheckout-loadingToaster-backgroundColor": "#333333",
     "optimizedCheckout-loadingToaster-textColor": "#ffffff",

--- a/templates/pages/checkout.html
+++ b/templates/pages/checkout.html
@@ -17,13 +17,13 @@
     <div class="checkoutHeader-content">
         <h1 class="is-srOnly">{{lang 'checkout.title'}}</h1>
         <h2 class="checkoutHeader-heading">
-            <a class="checkoutHeader-link" href="{{urls.home}}">
+            <div class="checkoutHeader-link">
                 {{#if checkout.header_image}}
                     <img alt="{{settings.store_logo.title}}" class="checkoutHeader-logo" id="logoImage" src="{{ checkout.header_image }}"/>
                 {{ else }}
                     <span class="header-logo-text">{{settings.store_logo.title}}</span>
                 {{/if}}
-            </a>
+            </div>
         </h2>
     </div>
 </header>

--- a/templates/pages/order-confirmation.html
+++ b/templates/pages/order-confirmation.html
@@ -16,13 +16,13 @@
     <div class="checkoutHeader-content">
         <h1 class="is-srOnly">{{lang 'checkout.title'}}</h1>
         <h2 class="checkoutHeader-heading">
-            <a class="checkoutHeader-link" href="{{urls.home}}">
+            <div class="checkoutHeader-link">
                 {{#if checkout.header_image}}
                     <img alt="{{settings.store_logo.title}}" class="checkoutHeader-logo" id="logoImage" src="{{ checkout.header_image }}"/>
                 {{ else }}
                     <span class="header-logo-text">{{settings.store_logo.title}}</span>
                 {{/if}}
-            </a>
+            </div>
         </h2>
     </div>
 </header>


### PR DESCRIPTION
With these changes, the "change independent consultant" text on the cart page will display at all times - both when there is already an independent consultant selected _and_ when one is not yet selected.

Additionally, the continue shopping button will now be hidden from the order confirmation page and the user will no longer be able to click the header image (to navigate back to home). 