### PR TITLE
update button language to change independent consultant on cart page

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -130,7 +130,7 @@
         },
         "find_affiliate": {
             "modal_title": "Change independent consultant",
-            "button": "change independent consultant"
+            "button": "change"
         }
     },
     "common": {


### PR DESCRIPTION
This will update the change independent consultant button text on the cart page to read "change" instead of "change independent consultant".
