### PR TITLE
Razoyo

### DIFF
--- a/assets/js/theme/consultant-details.js
+++ b/assets/js/theme/consultant-details.js
@@ -133,6 +133,7 @@ class ConsultantDetails {
      */
     getDetailsMoreInfoHtmlBlock(details) {
         let consultantFName = details.Name.split(" ")[0];
+        let formattedNumber = this.formatPhoneNumber(details.PhoneNumber);
 
         let $greetings   = $('.cdetails-greetings');
         let $headline    = $('.cdetails-headline');
@@ -141,8 +142,8 @@ class ConsultantDetails {
 
         $greetings.text(`hello, I'm ${consultantFName}!`);
         $headline.text(details.Headline || "Testing Shop or Host With Me Headline");
-        $phoneNumber.text(details.PhoneNumber || "888-888-8888");
-        $email.text(details.EmailAddress || "help@tastefullysimple.com");
+        $phoneNumber.text(formattedNumber);
+        $email.text(details.EmailAddress);
 
         // Social Media Links
         let $socialLinksContainer = $('.cdetails-more-info .socialLinks');
@@ -216,6 +217,10 @@ class ConsultantDetails {
     /* 
      * Helpers
      */
+
+    formatPhoneNumber(number) {
+        return number.replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3');
+    }
 
     createSocialMedia(url, social) {
         let $item = $('<li>', {'class': 'socialLinks-item'});

--- a/assets/js/theme/global/find-consultant.js
+++ b/assets/js/theme/global/find-consultant.js
@@ -225,9 +225,12 @@ class FindAConsultant {
     }
 
     selectConsultant(e) {
-        if (!($(e.target).hasClass('consultant-card') || $(e.target).is('img'))) {
-            return true;
+        // If "View my TS page" link is clicked,
+        // do nothing. Don't select the consultant
+        if ($(e.target).is('.ts-page-link .framelink-lg')) {
+            return;
         }
+
         $('.alertbox-error').hide();
         var $consultantCard = $(e.target).closest(".consultant-card");
         if (!$consultantCard.hasClass("selected")) {

--- a/assets/js/theme/global/ts-router.js
+++ b/assets/js/theme/global/ts-router.js
@@ -9,6 +9,7 @@ export default class TSRouter {
         this.checkUrlForBuyNow()
             || this.checkUrlForPartyId()
             || this.checkUrlForPartyPlannerId()
+            || this.checkUrlForMissingPartyId()
             || this.checkUrlForConsultantId()
             || this.checkUrlForConsultantWebSlug()
             || this.checkUrlForTest()
@@ -97,6 +98,17 @@ export default class TSRouter {
 
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    checkUrlForMissingPartyId() {
+        const matches = window.location.pathname.match(/^\/party-details/i);
+        if (matches && !TSCookie.SetPartyId()) {
+            this.showLoading();
+            window.location = '/';
+            return true;
         }
 
         return false;

--- a/assets/scss/custom/layout/_consultant-card.scss
+++ b/assets/scss/custom/layout/_consultant-card.scss
@@ -51,7 +51,6 @@
         }
     }
     .consultant-info {
-        cursor: auto;
         display: flex;
         flex-basis:65%;
         flex-direction: column;

--- a/assets/scss/custom/layout/_consultant-details.scss
+++ b/assets/scss/custom/layout/_consultant-details.scss
@@ -44,6 +44,7 @@
 // COL-1 & 2
 .cdetails-summary,
 .cdetails-more-info {
+    max-width: 365px;
     padding: 2.5rem 2rem;
     text-align: center;
 

--- a/templates/components/common/navigation-menu-custom.html
+++ b/templates/components/common/navigation-menu-custom.html
@@ -254,8 +254,13 @@
                             <a class="navPage-subMenu-action navPages-action" href="{{urls.account.wishlists.all}}">{{lang 'account.mobile_nav.wishlists'}}</a>
                         </li>
                         <li class="navPage-subMenu-item">
+                            <a class="navPage-subMenu-action navPages-action" href="/communication-preferences/">{{lang 'account.nav.preferences'}}</a>
+                        </li>
+                        {{!-- @razoyo: remove recently viewed from account nav
+                        <li class="navPage-subMenu-item">
                             <a class="navPage-subMenu-action navPages-action" href="{{urls.account.recent_items}}">{{lang 'account.nav.recently_viewed'}}</a>
                         </li>
+                        --}}
                         <li class="navPage-subMenu-item">
                             <a class="navPage-subMenu-action navPages-action" href="{{urls.account.details}}">{{lang 'account.nav.settings'}}</a>
                         </li>


### PR DESCRIPTION
- Find a Consultant modal - Search results - User has to click on the image now to select consultant (#249)
- Consultant page - Hide Phone and Email when they're empty string values (#240)
- Redirect to home if no party (#233)
- Communication preferences tab is missing in mobile (#243)
- Recently viewed tab is displayed and should be hidden on mobile (#242)