### PR TITLE
Razoyo

### DIFF
--- a/assets/js/theme/global/find-consultant.js
+++ b/assets/js/theme/global/find-consultant.js
@@ -333,7 +333,7 @@ class FindAConsultant {
 
         // Main consultant DOM rendering
         const defaultConsultantHtml =
-            `<span class="fa fa-map-marker fa-fw" aria-hidden="true"></span>
+            `<span class="fa fa-map-marker fa-lg" aria-hidden="true"></span>
                 <span class="headertoplinks-consult-text">Find a Consultant</span>`;
 
         const nameHtml =

--- a/assets/scss/custom/layout/_header.scss
+++ b/assets/scss/custom/layout/_header.scss
@@ -326,10 +326,14 @@
             color: $text-gray;
             display: flex;
             justify-content: flex-end;
-            max-width: 130px;
+            max-width: 125px;
             width: 100%;
+            .fa-lg {
+                font-size:16px;
+            }
             .headertoplinks-consult {
                 color: $text-gray;
+                padding-right:.1rem;
                 &:hover {
                     color: $text-gray;
                 }
@@ -342,11 +346,13 @@
                 padding: 0;
                 ul {
                     &.navUser-section {
+                        align-items: center;
                         display: flex;
                     }
                 }
                 .navUser-action {
                     color: $text-gray;
+                    line-height:1;
                     padding: 1rem 0.5rem;
                 }
                 .navUser-item--account {

--- a/templates/components/common/header.html
+++ b/templates/components/common/header.html
@@ -16,7 +16,7 @@
             </div>
             <div class="header-top-links">
                 <button type="button" class="headertoplinks-consult">
-                    <span class="fa fa-map-marker fa-fw" aria-hidden="true"></span>
+                    <span class="fa fa-map-marker fa-lg" aria-hidden="true"></span>
                     <span class="headertoplinks-consult-text">Find a Consultant</span>
                 </button>
                 <div class="headertoplinks-nav">


### PR DESCRIPTION
Fixed issue with icon alignment in sticky menu
Added fa-lg class to consultant icon in template and js
Set fa-lg to be 16px in the header-top-links
Reduced padding between elements for more equal alignment
Reduced max-width of container to better account for empty cart