### PR TITLE
Razoyo

### DIFF
--- a/assets/js/theme/global/ts-join-process.js
+++ b/assets/js/theme/global/ts-join-process.js
@@ -155,8 +155,8 @@ class TSJoinProcess {
         e.preventDefault();
         this.clearErrorMessages();
 
-        const email1 = $('#EmailAddress').val();
-        const email2 = $('#EmailAddress2').val();
+        const email1 = $('#Email').val();
+        const email2 = $('#Email2').val();
         const password1 = $('#Password').val();
 
         const $loginErrors = $('#loginErrors');
@@ -187,7 +187,7 @@ class TSJoinProcess {
     loginSuccess() {
         $('#FirstName').val('');
         $('#LastName').val('');
-        $('#EmailAddress2').val('');
+        $('#Email2').val('');
         $('#Password2').val('');
 
         const userInfo = $('#joinLoginForm').serialize();

--- a/assets/js/theme/global/ts-join-process.js
+++ b/assets/js/theme/global/ts-join-process.js
@@ -40,6 +40,8 @@ class TSJoinProcess {
     }
 
     init() {
+        this.checkTmpConsultant();
+
         switch (document.location.pathname) {
             case JOIN_PAGE:
                 this.renderJoin();
@@ -54,6 +56,27 @@ class TSJoinProcess {
                 this.renderCheckoutConfirmation();
             default:
                 break;
+        }
+    }
+
+    /**
+     * TST-301 make sure to affiliate previous consultant
+     * when user does not complete the join process
+     */
+    checkTmpConsultant() {
+        const tmpConsultant = localStorage.getItem('tmpConsultant');
+
+        if (tmpConsultant) {
+            const consultant = JSON.parse(tmpConsultant);
+
+            if (consultant.id) {
+                TSCookie.setConsultantId(consultant.id);
+                TSCookie.setConsultantName(consultant.name);
+            } else {
+                TSCookie.deleteConsultant();
+            }
+
+            localStorage.removeItem('tmpConsultant');
         }
     }
 
@@ -519,6 +542,13 @@ class TSJoinProcess {
         const afid = $consultantCard.data('afid') || null;
         const name = $consultantCard.data('name') || null;
 
+        const tmpConsultant = {
+            id: TSCookie.getConsultantId(),
+            name: TSCookie.getConsultantName(),
+        };
+
+        localStorage.setItem('tmpConsultant', JSON.stringify(tmpConsultant));
+
         this.api.updateJoinSession(userInfo, this.getUrlIdentifier())
             .done(() => {
                 TSCookie.setConsultantId(cid);
@@ -782,6 +812,7 @@ class TSJoinProcess {
         } else {
             $consultantCard.find('.consultant-header').show();
             $consultantCard.removeClass('selected');
+            $('#ConsultantId').val('');
         }
     }
 

--- a/assets/js/theme/global/ts-join-process.js
+++ b/assets/js/theme/global/ts-join-process.js
@@ -1,4 +1,5 @@
 import utils from '@bigcommerce/stencil-utils';
+import { confetti } from 'dom-confetti';
 import TSApi from '../common/ts-api';
 import TSCookie from '../common/ts-cookie';
 import ConsultantCard from '../common/consultant-card';
@@ -7,6 +8,7 @@ import JoinKitContentCard from '../common/join-kit-content-card';
 const JOIN_PAGE = '/join';
 const KIT_PAGE = '/join-kit/';
 const PERSONAL_INFO_PAGE = '/tell-us-about-yourself/';
+const CONFIRMATION_PAGE = '/welcome/';
 
 // Indicate which tab to be displayed in the join form
 const JOIN_FORM_TABS = {
@@ -48,6 +50,8 @@ class TSJoinProcess {
             case PERSONAL_INFO_PAGE:
                 this.renderPersonalInfo();
                 break;
+            case CONFIRMATION_PAGE:
+                this.renderCheckoutConfirmation();
             default:
                 break;
         }
@@ -95,6 +99,12 @@ class TSJoinProcess {
         } else {
             window.location.href = JOIN_PAGE;
         }
+    }
+
+    renderCheckoutConfirmation() {
+        this.removeClassContainer();
+        this.triggerConfetti();
+        localStorage.removeItem('isJoin');
     }
 
     /**
@@ -793,6 +803,17 @@ class TSJoinProcess {
                 </li>
             </ul>
         `);
+    }
+
+    /**
+     * Checkout Confirmation functions
+     */
+
+    triggerConfetti() {
+        const confettiRoots = document.querySelectorAll('[data-fun]');
+        confettiRoots.forEach(confettiRoot => {
+            confetti(confettiRoot);
+        });
     }
 
     /**


### PR DESCRIPTION
TST-319
Delete the isJoin item in localStorage when user gets redirected to the Congratulations Confirmation page - Also added the animation for the confetti

TST-297
Fixed Signup's email match validation

TST-320
Prevent user to continue to checkout when they unselect a consultant in Personal Info page
Applied TST-301: Added a tmpConsultant localStorage item to keep track of the previously selected consultant