### PR TITLE
Razoyo - Bug 1509

### DIFF
--- a/config.json
+++ b/config.json
@@ -53,6 +53,7 @@
     "ts_consultant_id": "0160785",
     "ts_affiliation_timer": 15,
     "ts_debug_mode": true,
+    "zoy_dev_mode": true,
     "hide_breadcrumbs": false,
     "hide_page_heading": false,
     "hide_category_page_heading": false,
@@ -406,7 +407,8 @@
       "images": {},
       "settings": {
         "ts_tsapi_base_url": "https://qa1-tsapi.tastefullysimple.com",
-        "ts_affiliation_timer": 15
+        "ts_affiliation_timer": 15,
+        "zoy_dev_mode": false
       }
     },
     {
@@ -432,7 +434,8 @@
         "ts_shop_more_url": "/shop/",
         "ts_tsapi_base_url": "https://stage-tsapi.tastefullysimple.com",
         "ts_join_store_url": "https://tastefully-simple-inc-sandbox-5.mybigcommerce.com",
-        "ts_affiliation_timer": 15
+        "ts_affiliation_timer": 15,
+        "zoy_dev_mode": false
       }
     },
     {
@@ -459,7 +462,8 @@
         "ts_tsapi_base_url": "https://tsapi.tastefullysimple.com",
         "ts_join_store_url": "https://join.tastefullysimple.com",
         "ts_affiliation_timer": 1440,
-        "ts_debug_mode": false
+        "ts_debug_mode": false,
+        "zoy_dev_mode": false
       }
     }
   ]

--- a/templates/components/common/ts-checkout.html
+++ b/templates/components/common/ts-checkout.html
@@ -60,15 +60,17 @@
     const themeSettings = context.themeSettings;
     const TS_DEBUG_MODE = themeSettings.ts_debug_mode;
 
-    setTimeout(function() {
-        window.location = '/cart.php';
-    }, getCookieSessionExpiration());
+    // To get rid of %20 (space) in the expiration's value
+    const expirationCookie = decodeURIComponent(getExpirationDateCookie());
+    const expiration = new Date(expirationCookie);
 
-    function getCookieSessionExpiration() {
-        // To get rid of %20 (space) in the expiration's value
-        const expirationCookie = decodeURIComponent(getCookie('affiliationExpiration'));
-        const expiration = new Date(expirationCookie);
+    if (expiration.toString !== 'Invalid Date') {
+        setTimeout(function() {
+            window.location = '/cart.php';
+        }, getCookieSessionExpiration(expiration));
+    }
 
+    function getCookieSessionExpiration(expiration) {
         if (TS_DEBUG_MODE) {
             console.warn('in Checkout::Affiliation cookies will expire on', expiration);
         }
@@ -76,7 +78,8 @@
         return expiration - Date.now();
     }
 
-    function getCookie(name) {
+    function getExpirationDateCookie() {
+        const name = 'affiliationExpiration';
         const value = `; ${document.cookie}`;
         const parts = value.split(`; ${name}=`);
         if (parts.length === 2) return parts.pop().split(';').shift();


### PR DESCRIPTION
- Fixed issue where cookie session checker goes infinite
loop in Shogun Editor page
- Added a new config to not run the deletion of old cookies
in a local stencil env