### PR TITLE
Razoyo - Bug 2064

### DIFF
--- a/assets/js/theme/global/ts-cart-subscription.js
+++ b/assets/js/theme/global/ts-cart-subscription.js
@@ -444,7 +444,7 @@ class CartSubscription extends FindAConsultant {
 
     initListeners() {
         // Bind To checkout Button
-        $('body').on('click', '.cart-actions .button--primary:not([disabled])', (e) => this.init(e));
+        $('body').on('click', '.cart-actions .button--primary:not([disabled]):not(.view-consultant-parties)', (e) => this.init(e));
 
         // Bind login submit
         $('body').on('submit', '#modal .login-form', (e) => this.login(e));

--- a/assets/js/theme/global/ts-find-consultant.js
+++ b/assets/js/theme/global/ts-find-consultant.js
@@ -262,7 +262,7 @@ export default class FindAConsultant {
     }
 
     openConsultantParties(e) {
-        const template = 'common/consultant-parties';
+        const template = 'common/findConsultant/consultant-parties';
         $('#modal').removeClass('modal-results');
         this.modal = defaultModal();
         e.preventDefault();


### PR DESCRIPTION
- Fixed the cart-subscription stuff is firing when clicking ‘continue' when it should only be firing when 'checkout’ is clicked.
- Fixed the template for finding a party changed locations and the name needs to be updated accordingly.