### PR TITLE
TST-738 — BUG 3439 Remove marketplace redirection from continue button

### DIFF
--- a/assets/js/theme/common/ts-cart-marketplace.js
+++ b/assets/js/theme/common/ts-cart-marketplace.js
@@ -45,7 +45,7 @@ export default class TsCartMarketplace {
                 this.modal = defaultModal();
                 this.modal.open({ size: 'small' });
                 this.modal.updateContent($('#marketplace-popup-container').html());
-            } else if (redirect) {
+            } else if (redirect && $('.view-consultant-parties').attr('class') === undefined) {
                 window.location = '/checkout';
             }
         });


### PR DESCRIPTION
If a customer has to select a party, a continue button is displayed. This button should not trigger the checkout redirection from the marketplace validation. This redirection should be triggered only when there is no button with the class "view-consultant-parties".