### PR TITLE
TST-765 — Remove Styleguide page from Google Index

### DIFF
--- a/templates/layout/base-empty.html
+++ b/templates/layout/base-empty.html
@@ -40,6 +40,7 @@
 
         {{!-- @razoyo: add fontawesome --}}
         <script src="https://kit.fontawesome.com/2ac3125738.js" crossorigin="anonymous"></script>
+        {{#block "additional_head"}}{{/block}}
     </head>
     <body>
         {{> components/common/gtm-body }}

--- a/templates/pages/custom/page/styleguide.html
+++ b/templates/pages/custom/page/styleguide.html
@@ -1,3 +1,7 @@
+{{#partial "additional_head"}}
+<meta name="robots" content="noindex" />
+{{/partial}}
+{{#partial "page"}}
 <section class="tsi-styleguide" style="visibility:hidden;">
     <header>
         <h1>
@@ -242,7 +246,7 @@
             <div class="styleitem-content">
                 <div class="styleicon-item">
                     <div class="styleicon-social">
-                        <h3 class="guide-label">Social</h3> 
+                        <h3 class="guide-label">Social</h3>
                         <div class="social-links">
                             <div class="icon-label">
                                 <a class="icon-social-facebook" href="https://facebook.com">Facebook</a>
@@ -376,7 +380,7 @@
                             </div>
                             <div class="icon-label">
                                 <span class="icon-badge-tsapproved-solid"></span>
-                                <span class="guide-label">class: icon-badge-tsapproved-solid</span>                            
+                                <span class="guide-label">class: icon-badge-tsapproved-solid</span>
                             </div>
                             <div class="icon-label">
                                 <span class="icon-badge-ts"></span>
@@ -389,15 +393,15 @@
                         <div class="special-icons">
                             <div class="icon-label">
                                 <span class="icon-special-arrow"></span>
-                                <span class="guide-label">class: icon-special-arrow</span>                            
+                                <span class="guide-label">class: icon-special-arrow</span>
                             </div>
                             <div class="icon-label">
                                 <span class="icon-special-confetti"></span>
-                                <span class="guide-label">class: icon-special-confetti</span>                           
+                                <span class="guide-label">class: icon-special-confetti</span>
                             </div>
                             <div class="icon-label">
                                 <span class="icon-special-plate"></span>
-                                <span class="guide-label">class: icon-special-plate</span>                           
+                                <span class="guide-label">class: icon-special-plate</span>
                             </div>
                             <div class="icon-label">
                                 <span class="icon-special-morecash"></span>
@@ -926,4 +930,5 @@
         </div>
     </main>
 </section>
+{{/partial}}
 {{> layout/base-empty}}


### PR DESCRIPTION
This update fixes the layout implementation on the Styleguide page and also tells Google to not index the page. The updates may take a few days to be implemented by the Google Bot.