### PR TITLE
5056 and 5057 — Checkout with TST; display Choose Party modal

### DIFF
--- a/assets/js/theme/common/ts-cart-affiliation.js
+++ b/assets/js/theme/common/ts-cart-affiliation.js
@@ -80,7 +80,7 @@ export default class TSCartAffiliation {
             $(this.noSelectionError).hide();
 
             if (e.target === document.getElementById('tsacf-shopdirect')) {
-                $(this.checkoutButton).html('check out');
+                $(this.checkoutButton).html('checkout');
                 $(this.checkoutButton).removeAttr('disabled');
                 $(this.checkoutButton).removeAttr('onclick');
             } else {
@@ -223,7 +223,7 @@ export default class TSCartAffiliation {
     }
 
     enableCheckout() {
-        $(this.checkoutButton).html('check out');
+        $(this.checkoutButton).html('checkout');
         $(this.checkoutButton).removeAttr('onclick');
         $(this.checkoutButton).removeAttr('disabled');
     }

--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -78,6 +78,6 @@ export default class Global extends PageManager {
             this.context.customerId, this.context.productId ? this.context.productId : false,
             this.context.subscriptionManagement, this.context.customerEmail,
         );
-        subscriptionCart();
+        subscriptionCart(themeSettings);
     }
 }

--- a/templates/components/common/ts-cookie.html
+++ b/templates/components/common/ts-cookie.html
@@ -193,6 +193,15 @@
 
             setTest: function(value) {
                 Cookies.set('_test', value);
+            },
+
+            getConsultantData() {
+                return {
+                    name: this.getConsultantName(),
+                    id: this.getConsultantId(),
+                    image: this.getConsultantImage(),
+                    hasOpenParty: this.hasOpenParty()
+                };
             }
         };
     })(window);


### PR DESCRIPTION
This update enables the customers ordering Autoship products to use the option "Shop directly with Tastefully Simple". It also asks the customer to select a party in case the selected consultant has open parties.

It also updates the word "check out" to "checkout" on the cart page.