### PR TITLE
5056 and 5057 — Checkout with TST; display Choose Party modal

### DIFF
--- a/assets/js/theme/global/custom/subscription-cart.js
+++ b/assets/js/theme/global/custom/subscription-cart.js
@@ -7,6 +7,7 @@ import TSCookie from '../../common/ts-cookie';
 import ConsultantParties from '../../common/consultant-parties';
 
 window.allowSubscriptionCheckout = false;
+window.boldCheckoutSubmitted = false;
 
 class SubscriptionCart {
     constructor(tsConsultantId) {
@@ -80,6 +81,9 @@ class SubscriptionCart {
         // Bind To checkout Button
         $('#page-wrapper').on('click', '.cart-actions .button--primary', (event) => {
             event.preventDefault();
+            if (window.boldCheckoutSubmitted === true) {
+                return;
+            }
             this.init(event);
         });
 


### PR DESCRIPTION
This update enables the customers ordering Autoship products to use the option "Shop directly with Tastefully Simple". It also asks the customer to select a party in case the selected consultant has open parties.

It also updates the word "check out" to "checkout" on the cart page.