### PR TITLE
5055 — Verify if cart has been submitted by Bold before showing modals

### DIFF
--- a/assets/js/theme/global/custom/subscription-cart.js
+++ b/assets/js/theme/global/custom/subscription-cart.js
@@ -7,6 +7,7 @@ import TSCookie from '../../common/ts-cookie';
 import ConsultantParties from '../../common/consultant-parties';
 
 window.allowSubscriptionCheckout = false;
+window.boldCheckoutSubmitted = false;
 
 class SubscriptionCart {
     constructor(tsConsultantId) {
@@ -80,6 +81,9 @@ class SubscriptionCart {
         // Bind To checkout Button
         $('#page-wrapper').on('click', '.cart-actions .button--primary', (event) => {
             event.preventDefault();
+            if (window.boldCheckoutSubmitted === true) {
+                return;
+            }
             this.init(event);
         });
 


### PR DESCRIPTION
This update will prevent the modals from being displayed again once the Bold subscription cart has been submitted. This is necessary after the subscription cashier override added to Bigcommerce's script manager.